### PR TITLE
Declare compatibility with vscode 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Flow support for VS Code",
     "displayName": "Flow Language Support",
     "engines": {
-        "vscode": "1.5.x"
+        "vscode": "1.6.x"
     },
     "categories": [
         "Languages",


### PR DESCRIPTION
VS Code updated to 1.6.0 yesterday.  I've checked it out, and I can't find any compatibility issues with VS Code 1.6.x.

The plugin won't run at all without updating this declaration, so as a daily user of the VS Code extension, I'd be grateful to see this go through sooner rather than later!