### PR TITLE
Support automatically checking for the node_modules version of Flow

### DIFF
--- a/lib/flowMain.js
+++ b/lib/flowMain.js
@@ -19,6 +19,7 @@ import {DeclarationSupport} from './flowDeclaration';
 import {setupDiagnostics} from './flowDiagnostics';
 
 import {checkNode, checkFlow, isFlowEnabled} from './utils'
+import {clearWorkspaceCaches} from './pkg/flow-base/lib/FlowHelpers'
 
 type Context = {
 	subscriptions: Array<vscode.Disposable>
@@ -37,6 +38,7 @@ export function activate(context: Context): void {
 	global.vscode = vscode
 	checkNode()
 	checkFlow()
+
 	// Language features
 	languages.forEach(lang => {
 		context.subscriptions.push(vscode.languages.registerHoverProvider(lang, new HoverSupport));
@@ -48,3 +50,7 @@ export function activate(context: Context): void {
 	// Diagnostics
 	setupDiagnostics(context.subscriptions);
 }
+
+vscode.workspace.onDidChangeConfiguration(params => {
+	clearWorkspaceCaches();
+});

--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -150,14 +150,18 @@ async function canFindFlow(flowPath: string): Promise<boolean> {
  *   preferences in Atom, in which case the return value will be stale.
  */
 async function getPathToFlow(): Promise<string> {
-  const config = global.vscode.workspace.getConfiguration('flow').get('pathToFlow')
-  if (await canFindFlow(config)) {
-    return config
+  const config = global.vscode.workspace.getConfiguration('flow')
+  const userPath = config.get('pathToFlow')
+
+  if (await canFindFlow(userPath)) {
+    return userPath
   }
-  if (await canFindFlow(fallbackNodeModuleFlowLocation())){
+
+  const shouldUseNodeModule = config.get('useNPMPackagedFlow')
+  if (shouldUseNodeModule && await canFindFlow(fallbackNodeModuleFlowLocation())){
     return fallbackNodeModuleFlowLocation()
   }
-  return config
+  return userPath
 }
 
 /**

--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -124,6 +124,12 @@ function isOptional(param: string): boolean {
   return lastChar === '?';
 }
 
+function clearWorkspaceCaches() {
+  flowPathCache.reset();
+  flowConfigDirCache.reset();
+  global.cachedPathToFlowBin = undefined;
+}
+
 async function isFlowInstalled(): Promise<boolean> {
   const flowPath = await getPathToFlow();
   if (!flowPathCache.has(flowPath)) {
@@ -144,32 +150,41 @@ async function canFindFlow(flowPath: string): Promise<boolean> {
 }
 
 /**
- * @return The path to Flow on the user's machine. First using the the user's config, then looking into
- *   the node_modules for the project.
- *   It is recommended not to cache the result of this function in case the user updates his or her 
- *   preferences in Atom, in which case the return value will be stale.
+ * @return The path to Flow on the user's machine. First using the the user's 
+ *   config, then looking into the node_modules for the project.
+ * 
+ *   It is cached, so it is expected that changing the users settings will 
+ *   trigger a call to `clearWorkspaceCaches`.
  */
+
 async function getPathToFlow(): Promise<string> {
-  const config = global.vscode.workspace.getConfiguration('flow')
-  const userPath = config.get('pathToFlow')
+  if (global.cachedPathToFlowBin) { return global.cachedPathToFlowBin }
 
+  const config = global.vscode.workspace.getConfiguration('flow');
+  const shouldUseNodeModule = config.get('useNPMPackagedFlow');
+
+  if (shouldUseNodeModule && await canFindFlow(nodeModuleFlowLocation())){
+    global.cachedPathToFlowBin = nodeModuleFlowLocation(); 
+    return global.cachedPathToFlowBin
+  }
+
+  const userPath = config.get('pathToFlow');
   if (await canFindFlow(userPath)) {
-    return userPath
+    global.cachedPathToFlowBin = userPath 
+    return global.cachedPathToFlowBin
   }
 
-  const shouldUseNodeModule = config.get('useNPMPackagedFlow')
-  if (shouldUseNodeModule && await canFindFlow(fallbackNodeModuleFlowLocation())){
-    return fallbackNodeModuleFlowLocation()
-  }
-  return userPath
+  // Final fallback, mainly so we complete the promise<string> implmentation
+  return "flow"
 }
 
 /**
- * @return The potential path to Flow on the user's machine if they are using NPM/Yarn to manage
+ * @returnThe potential path to Flow on the user's machine if they are using NPM/Yarn to manage
  * their installs of flow.
  */
-function fallbackNodeModuleFlowLocation(): string {
-  return global.vscode.workspace.rootPath + "/node_modules/.bin/flow"
+function nodeModuleFlowLocation(): string {
+  const flowBin = process.platform === 'win32' ? 'flow.cmd' : 'flow'
+  return `${global.vscode.workspace.rootPath}/node_modules/.bin/${flowBin}`
 }
 
 function getStopFlowOnExit(): boolean {
@@ -212,4 +227,5 @@ module.exports = {
   processAutocompleteItem,
   groupParamNames,
   flowCoordsToAtomCoords,
+  clearWorkspaceCaches
 };

--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -125,7 +125,7 @@ function isOptional(param: string): boolean {
 }
 
 async function isFlowInstalled(): Promise<boolean> {
-  const flowPath = getPathToFlow();
+  const flowPath = await getPathToFlow();
   if (!flowPathCache.has(flowPath)) {
     flowPathCache.set(flowPath, await canFindFlow(flowPath));
   }
@@ -144,12 +144,28 @@ async function canFindFlow(flowPath: string): Promise<boolean> {
 }
 
 /**
- * @return The path to Flow on the user's machine. It is recommended not to cache the result of this
- *   function in case the user updates his or her preferences in Atom, in which case the return
- *   value will be stale.
+ * @return The path to Flow on the user's machine. First using the the user's config, then looking into
+ *   the node_modules for the project.
+ *   It is recommended not to cache the result of this function in case the user updates his or her 
+ *   preferences in Atom, in which case the return value will be stale.
  */
-function getPathToFlow(): string {
-  return global.vscode.workspace.getConfiguration('flow').get('pathToFlow')
+async function getPathToFlow(): Promise<string> {
+  const config = global.vscode.workspace.getConfiguration('flow').get('pathToFlow')
+  if (await canFindFlow(config)) {
+    return config
+  }
+  if (await canFindFlow(fallbackNodeModuleFlowLocation())){
+    return fallbackNodeModuleFlowLocation()
+  }
+  return config
+}
+
+/**
+ * @return The potential path to Flow on the user's machine if they are using NPM/Yarn to manage
+ * their installs of flow.
+ */
+function fallbackNodeModuleFlowLocation(): string {
+  return global.vscode.workspace.rootPath + "/node_modules/.bin/flow"
 }
 
 function getStopFlowOnExit(): boolean {

--- a/lib/pkg/flow-base/lib/FlowProcess.js
+++ b/lib/pkg/flow-base/lib/FlowProcess.js
@@ -153,7 +153,7 @@ export class FlowProcess {
 
   /** Starts a Flow server in the current root */
   async _startFlowServer(): Promise<void> {
-    const pathToFlow = getPathToFlow();
+    const pathToFlow = await getPathToFlow();
     // `flow server` will start a server in the foreground. asyncExecute
     // will not resolve the promise until the process exits, which in this
     // case is never. We need to use spawn directly to get access to the
@@ -342,7 +342,7 @@ export class FlowProcess {
       ...args,
       '--from', 'nuclide',
     ];
-    const pathToFlow = getPathToFlow();
+    const pathToFlow = await getPathToFlow();
     const ret = await asyncExecute(pathToFlow, args, options);
     if (ret.exitCode !== 0) {
       // TODO: bubble up the exit code via return value instead

--- a/lib/pkg/flow-base/lib/FlowProcess.js
+++ b/lib/pkg/flow-base/lib/FlowProcess.js
@@ -139,7 +139,8 @@ export class FlowProcess {
           // don't want to log because it just means the server is busy and we don't want to wait.
           if (!couldRetry && !suppressErrors) {
             // not sure what happened, but we'll let the caller deal with it
-            logger.error(`Flow failed: flow ${args.join(' ')}. Error: ${JSON.stringify(e)}`);
+            const pathToFlow = await getPathToFlow();
+            logger.error(`Flow failed: ${pathToFlow} ${args.join(' ')}. Error: ${JSON.stringify(e)}`);
           }
           throw e;
         }

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -2,13 +2,10 @@
 
 import spawn from 'cross-spawn';
 import {window, workspace} from 'vscode'
+import {getPathToFlow} from "../pkg/flow-base/lib/FlowHelpers"
 
 const NODE_NOT_FOUND = '[Flow] Cannot find node in PATH. The simpliest way to resolve it is install node globally'
 const FLOW_NOT_FOUND = '[Flow] Cannot find flow in PATH. Try to install it by npm install flow-bin -g'
-
-function getPathToFlow(): string {
-	return workspace.getConfiguration('flow').get('pathToFlow')
-}
 
 export function isFlowEnabled() {
 	return workspace.getConfiguration('flow').get('enabled')
@@ -36,9 +33,10 @@ export function checkNode() {
 	}
 }
 
-export function checkFlow() {
+export async function checkFlow() {
+	const path = await getPathToFlow()
 	try {
-		const check = spawn(process.platform === 'win32' ? 'where' : 'which', [getPathToFlow()])
+		const check = spawn(process.platform === 'win32' ? 'where' : 'which', [path])
 		let
 		  flowOutput = "",
 			flowOutputError = ""

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Stop Flow on Exit"
+                },
+                "flow.useNPMPackagedFlow": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Support using flow through your node_modules folder, WARNING: Checking this box is a security risk. When you open a project we will immediately run code contained within it."
                 }
             }
         }


### PR DESCRIPTION
Addresses https://github.com/flowtype/flow-for-vscode/issues/41 by proxy too.

We have multiple apps that use different versions of Flow, which makes it tough to keep VS Code in a good state. We couldn't use an absolute path, or per-project settings (as they wouldn't work per user) and so I think this is a good fallback.