### PR TITLE
Ensure that we do not pass a negative number to VS Code for error diagnostics

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -123,9 +123,11 @@ function applyDiagnostics(diagnostics) {
 	for (let file in diagnostics) {
 		const errors = diagnostics[file];
 		const targetResource = vscode.Uri.file(file);
-
 		const diags = errors.map(error => {
-			const range = new vscode.Range(error.startLine - 1, error.startCol - 1, error.endLine - 1, error.endCol);
+			// don't allow non-0 lines
+			const startLine = Math.max(0, error.startLine - 1)
+			const endLine = Math.max(0, error.endLine - 1)
+			const range = new vscode.Range(startLine, error.startCol - 1, endLine, error.endCol);
 			const location = new vscode.Location(targetResource, range);
 
 			const diag =  new vscode.Diagnostic(range, error.msg, mapSeverity(error.severity));


### PR DESCRIPTION
Hello there, looks like if Flow gives an error with 0 as the line, this extension will not show results:

> `flow status --pretty packages/jest-editor-support/src/test_reconciler.js | pbcopy`

```json
{
  "flowVersion":"0.36.0",
  "errors":[
    {
      "kind":"internal",
      "level":"error",
      "message":[
        {
          "context":null,
          "descr":"Internal error: Failure(\"attempt to refine type TestReconcilationState\")\n",
          "type":"Blame",
          "loc":{
            "source":"/Users/orta/dev/projects/vscode/jest/packages/jest-editor-support/src/test_reconciler.js",
            "type":"SourceFile",
            "start":{"line":0,"column":1,"offset":0},
            "end":{"line":0,"column":0,"offset":0}
          },
          "path":"/Users/orta/dev/projects/vscode/jest/packages/jest-editor-support/src/test_reconciler.js",
          "line":0,
          "endline":0,
          "start":1,
          "end":0
        }
      ]
    },
    {
      ...
```

This fixes that 👍 