### PR TITLE
Add support for showing Flow messages to the User via an output channel

### DIFF
--- a/lib/flowLogging.js
+++ b/lib/flowLogging.js
@@ -1,0 +1,8 @@
+/**
+ * Adds a gloabl that is used inside consoleAppender.js to output console messages
+ * to the user, instead of to the developer console.
+ */
+export function setupLogging(): void {
+  const channel = vscode.window.createOutputChannel("Flow");
+  global.flowOutputChannel = channel
+}

--- a/lib/flowMain.js
+++ b/lib/flowMain.js
@@ -19,6 +19,7 @@ import {DeclarationSupport} from './flowDeclaration';
 import {setupDiagnostics} from './flowDiagnostics';
 
 import {checkNode, checkFlow, isFlowEnabled} from './utils'
+import {setupLogging} from "./flowLogging"
 
 type Context = {
 	subscriptions: Array<vscode.Disposable>
@@ -35,6 +36,7 @@ export function activate(context: Context): void {
 		return
 	}
 	global.vscode = vscode
+	setupLogging()
 	checkNode()
 	checkFlow()
 	// Language features

--- a/lib/pkg/nuclide-logging/lib/consoleAppender.js
+++ b/lib/pkg/nuclide-logging/lib/consoleAppender.js
@@ -37,6 +37,13 @@ function layout(loggingEvent: any): Array<any> {
 function consoleAppender(): (loggingEvent: any) => void {
   return loggingEvent => {
     console.log.apply(console, layout(loggingEvent)); // eslint-disable-line no-console
+
+    // Also support outputing information into a VS Code console,
+    // it is only string based, so we only take the first string
+    if (global.flowOutputChannel) {
+      const message = layout(loggingEvent)[0]
+      global.flowOutputChannel.appendLine(message.replace("nuclide -", "flow -"))
+    }
   };
 }
 


### PR DESCRIPTION
Bah, looks like the a change online endings for flowMain as with #53  - so far this seems to be the only file that has this issue, is it worth having it switched over (like these diffs are doing?)

This PR adds the ability for users to see any problems, perviously to debug a "why isn't this working?" you would have to open the web inspector for VS Code.
 
![screen shot 2016-12-04 at 20 33 52](https://cloud.githubusercontent.com/assets/49038/20869035/b3be4c1a-ba61-11e6-9c65-e7abdde21b10.png)

---

I initially tried building this via log4js' appender system, but I couldn't get it to ever echo anything out. 

I'm not 100% on whether it's a good idea to add VS Code specific bits inside any `lib/pkg/nuclide-*` but it looks like the libraries are pretty mature on nuclide's sides, and so it feels like an ok idea. 