### PR TITLE
Fix the compile step to work on Windows as well

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Transpiling ./lib"
-node_modules/.bin/babel ./lib --out-dir=./build --source-maps $@

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "./compile.sh",
-        "compile": "./compile.sh --watch",
+        "vscode:prepublish": "babel ./lib --out-dir=./build --source-maps",
+        "compile": "babel ./lib --out-dir=./build --source-maps --watch",
         "test": "flow check"
     },
     "dependencies": {


### PR DESCRIPTION
The package.json scripts delegated to a `.sh` script, which does not work on Windows. The easiest thing to do is to just have the `package.json` run babel directly.

To test, I checked out this branch on Windows and OSX. I opened the repo with vscode, and hit CMD+Shift+B (CTR+Shift+B on Windows). Previously this failed to build on Windows. Now it builds fine on both.

Also made sure that `vsce package` works on both Windows and OSX (though had to make sure to upgrade vsce to >= 1.16 due to https://github.com/Microsoft/vscode-vsce/issues/130)

If this command gets more complicated, we probably could switch to a more cross-platform scripting language, like JavaScript 😛 