### PR TITLE
Hitting run when debugging starts the babel watcher 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/build"
+			"outDir": "${workspaceRoot}/build",
+			"preLaunchTask": "npm"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,6 @@
 	// we run the custom script "compile" as defined in package.json
 	"args": ["run", "compile", "--loglevel", "silent"],
 
-	// Wether the babel compiler is started in watching mode
+	// Whether the babel compiler is started in watching mode
 	"isWatching": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+### Master
+
+* When you want to work on the flow-for-vscode project, pressing run will start the
+  babel build watcher task - orta
+
+### 4.0
+
+* Adds the ability to use flow from your project's node_modules folder. 
+  This is a security risk ( see https://github.com/facebook/nuclide/issues/570) and so it
+  is hidden behind a user setting of `useNPMPackagedFlow` which needs to be set to `true`
+  for it to work. - orta #53
+* Show flow errors that start at line 0 - orta #54 


### PR DESCRIPTION
You can set a pre-launch task to ensure that running the extension in dev mode enforces the watcher to start.

Also adds a CHANGELOG, I've got no qualms about what the format should be, so I just wrote one similar to how I do it for [Danger](https://github.com/danger/danger-js/blob/master/changelog.md).

Fixes #59 