### PR TITLE
Document debugger setup for flow-remove-types and Babel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Follow the [instructions](https://code.visualstudio.com/docs/editor/extension-ga
 
 * You should set workspace preference to disable default syntax validation from Visual Studio Code: `"javascript.validate.enable": false`.
 
+## Debugger configuration
+
+First, follow the [instructions](https://code.visualstudio.com/Docs/editor/debugging#_launch-configurations) to setup your launch configuration file, `launch.json`.
+
+To use [flow-remove-types](https://github.com/flowtype/flow-remove-types):
+
+* Follow the [flow-remove-type Quick Start](https://flowtype.org/docs/running.html#flow-remove-types-quick-start).
+* In `launch.json`, add `"runtimeArgs": ["-r", "flow-remove-types/register"]` to the "launch" configuration.
+
+To use [Babel](https://babeljs.io):
+
+* Follow the [Babel Quick Start](https://flowtype.org/docs/running.html#babel-quick-start).
+* Install [babel-register](http://babeljs.io/docs/core-packages/babel-register/).
+* In `.babelrc`, add `"retainLines": true`.
+* In `launch.json`, add `"runtimeArgs": ["-r", "babel-register"]` to the "launch" configuration.
+
 ## About
 
 This plugin is built on top of [Nuclide](https://github.com/facebook/nuclide)'s Flow support.


### PR DESCRIPTION
I was unable to find clear instructions on how to setup VS Code to debug Flow code so thought it'd be worth documenting my setup. This works with both the "node" and "node2" debugger protocols.

I've found flow-remove-types to work most robustly. With Babel, VS Code will always pause on the first line.

The babel setup is partially taken from https://medium.com/@katopz/how-to-debug-es6-nodejs-with-vscode-8d00bd6c4f94, though the sourceMaps configuration documented there is not required when using `"retainLines": true`. I've not been able to get sourceMaps to work with Babel and VS Code, see Microsoft/vscode#5728 for more on the current status.