### PR TITLE
Always use where command provided by Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Master
-
+* Uses the absolute path to the `where` command provided by Windows - JPanneel #69
 * Uses the new VS Code autocompletion API for functions - orta #51
 * When you want to work on the flow-for-vscode project, pressing run will start the
   babel build watcher task - orta

--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -142,7 +142,8 @@ async function isFlowInstalled(): Promise<boolean> {
 async function canFindFlow(flowPath: string): Promise<boolean> {
   try {
     // https://github.com/facebook/nuclide/issues/561
-    await checkOutput(process.platform === 'win32' ? 'where' : 'which', [flowPath]);
+    const {command, args} = buildSearchFlowCommand(flowPath)
+    await checkOutput(command, args);
     return true;
   } catch (e) {
     return false;
@@ -179,12 +180,36 @@ async function getPathToFlow(): Promise<string> {
 }
 
 /**
- * @returnThe potential path to Flow on the user's machine if they are using NPM/Yarn to manage
+ * @return The potential path to Flow on the user's machine if they are using NPM/Yarn to manage
  * their installs of flow.
  */
 function nodeModuleFlowLocation(): string {
-  const flowBin = process.platform === 'win32' ? 'flow.cmd' : 'flow'
-  return `${global.vscode.workspace.rootPath}/node_modules/.bin/${flowBin}`
+  if (process.platform === 'win32') {
+    return `${global.vscode.workspace.rootPath}\\node_modules\\.bin\\flow.cmd`
+  } else {
+    return `${global.vscode.workspace.rootPath}/node_modules/.bin/flow`
+  }
+}
+
+/**
+ * @return The command and arguments used to test the presence of flow according to platform.
+ */
+function buildSearchFlowCommand(testPath: string): {command: string, args: Array<string>} {
+  if (process.platform !== 'win32') {
+    return {
+      command: 'which',
+      args: [testPath]
+    }
+  } else {
+    const splitCharLocation = testPath.lastIndexOf('\\')
+    const command = testPath.substring(splitCharLocation+1, testPath.length)
+    const searchDirectory = testPath.substring(0, splitCharLocation)
+    const args = !searchDirectory ? [command] : ['/r', searchDirectory, command]
+    return {
+      command: `${process.env.SYSTEMROOT || 'C:\\Windows'}\\System32\\where`,
+      args: args
+    }
+  }
 }
 
 function getStopFlowOnExit(): boolean {
@@ -219,6 +244,7 @@ function flowCoordsToAtomCoords(flowCoords: FlowLocNoSource): FlowLocNoSource {
 }
 
 module.exports = {
+  buildSearchFlowCommand,
   findFlowConfigDir,
   getPathToFlow,
   getStopFlowOnExit,

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -2,7 +2,10 @@
 
 import spawn from 'cross-spawn';
 import {window, workspace} from 'vscode'
-import {getPathToFlow} from "../pkg/flow-base/lib/FlowHelpers"
+import {
+	buildSearchFlowCommand,
+	getPathToFlow
+} from "../pkg/flow-base/lib/FlowHelpers"
 
 const NODE_NOT_FOUND = '[Flow] Cannot find node in PATH. The simpliest way to resolve it is install node globally'
 const FLOW_NOT_FOUND = '[Flow] Cannot find flow in PATH. Try to install it by npm install flow-bin -g'
@@ -36,7 +39,8 @@ export function checkNode() {
 export async function checkFlow() {
 	const path = await getPathToFlow()
 	try {
-		const check = spawn(process.platform === 'win32' ? 'where' : 'which', [path])
+		const {command, args} = buildSearchFlowCommand(path)
+		const check = spawn(command, args)
 		let
 		  flowOutput = "",
 			flowOutputError = ""

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
                 "flow.pathToFlow": {
                     "type": "string",
                     "default": "flow",
-                    "description": "Path to flow binary"
+                    "description": "Path to flow binary. On Windows use '\\\\' as directory separator"
                 },
                 "flow.stopFlowOnExit": {
                     "type": "boolean",


### PR DESCRIPTION
#69 

By using the absolute path to the where executable provided by Windows
we avoid issues with other variants of the where command on the user's
path.

C:\Windows\System32\where.exe can be used to search a directory:
where /r <dir> <command>