### PR TITLE
Fix absolute flow path on Windows

### DIFF
--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -18,6 +18,7 @@ import {checkOutput} from '../../commons-node/process';
 import fsPromise from '../../commons-node/fsPromise';
 import LRU from 'lru-cache';
 import invariant from 'assert';
+import path from 'path';
 
 const flowConfigDirCache: LRUCache<string, Promise<?string>> = LRU({
   max: 10,
@@ -104,8 +105,8 @@ function groupParamNames(paramNames: Array<string>): Array<Array<string>> {
       }
       return [ordinary, optional];
     },
-    [[], []]
-  );
+      [[], []]
+    );
 
   const groupedParams = ordinaryParams.map(param => [param]);
   const lastParam = groupedParams[groupedParams.length - 1];
@@ -141,6 +142,10 @@ async function isFlowInstalled(): Promise<boolean> {
 
 async function canFindFlow(flowPath: string): Promise<boolean> {
   try {
+    if (path.isAbsolute(flowPath)) {
+      // where does not support absolute paths
+      return await fsPromise.exists(flowPath);
+    }
     // https://github.com/facebook/nuclide/issues/561
     await checkOutput(process.platform === 'win32' ? 'where' : 'which', [flowPath]);
     return true;
@@ -170,7 +175,7 @@ async function getPathToFlow(): Promise<string> {
 
   const userPath = config.get('pathToFlow');
   if (await canFindFlow(userPath)) {
-    global.cachedPathToFlowBin = userPath 
+    global.cachedPathToFlowBin = userPath
     return global.cachedPathToFlowBin
   }
 
@@ -184,7 +189,7 @@ async function getPathToFlow(): Promise<string> {
  */
 function nodeModuleFlowLocation(): string {
   const flowBin = process.platform === 'win32' ? 'flow.cmd' : 'flow'
-  return `${global.vscode.workspace.rootPath}/node_modules/.bin/${flowBin}`
+  return path.join(global.vscode.workspace.rootPath, 'node_modules', '.bin', flowBin);
 }
 
 function getStopFlowOnExit(): boolean {

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -3,6 +3,8 @@
 import spawn from 'cross-spawn';
 import {window, workspace} from 'vscode'
 import {getPathToFlow} from "../pkg/flow-base/lib/FlowHelpers"
+import fsPromise from '../pkg/commons-node/fsPromise';
+import path from 'path';
 
 const NODE_NOT_FOUND = '[Flow] Cannot find node in PATH. The simpliest way to resolve it is install node globally'
 const FLOW_NOT_FOUND = '[Flow] Cannot find flow in PATH. Try to install it by npm install flow-bin -g'
@@ -34,9 +36,17 @@ export function checkNode() {
 }
 
 export async function checkFlow() {
-	const path = await getPathToFlow()
+	const flowPath = await getPathToFlow()
 	try {
-		const check = spawn(process.platform === 'win32' ? 'where' : 'which', [path])
+		if (process.platform === 'win32' && path.isAbsolute(flowPath)) {
+			// where does not support absolute paths
+			const exists = await fsPromise.exists(flowPath);
+			if (!exists) {
+				throw new Error(`Flow in ${flowPath} does not exist`);
+			} 
+			return;
+		}
+		const check = spawn(process.platform === 'win32' ? 'where' : 'which', [flowPath])
 		let
 		  flowOutput = "",
 			flowOutputError = ""


### PR DESCRIPTION
This fixes the handling of absolute flow binary paths on Windows, which occurs both with user-specified flow paths and with flow.useNPMPackagedFlow.

The reason for the issue is that where.exe does not support absolute paths.