### PR TITLE
Check on edit

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.3.2",
+	"version": "0.1.0",
 
 	// we want to run npm
 	"command": "npm",
@@ -23,5 +23,5 @@
 	"args": ["run", "compile", "--loglevel", "silent"],
 
 	// Whether the babel compiler is started in watching mode
-	"isWatching": true
+	"isBackground": true
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Follow the [instructions](https://code.visualstudio.com/docs/editor/extension-ga
 * `flow.stopFlowOnExit` (default: true) stop flow server on exit from Project
 * `flow.enabled` (default: true) you can disable flow for some Project for example
 * `flow.useNPMPackagedFlow` (default: false) you can also run Flow by defining it in your `package.json`
+* `flow.showStatus` (default: `true`) If `true` will display a spinner in the statusbar while flow is type checking.
 
 ## Features
 
@@ -27,6 +28,7 @@ Follow the [instructions](https://code.visualstudio.com/docs/editor/extension-ga
 * Go to Definition / Peek Definition
 * Diagnostics (Errors, Warnings)
 * Hover type information
+* Progress indicator
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Follow the [instructions](https://code.visualstudio.com/docs/editor/extension-ga
 * `flow.enabled` (default: true) you can disable flow for some Project for example
 * `flow.useNPMPackagedFlow` (default: false) you can also run Flow by defining it in your `package.json`
 * `flow.showStatus` (default: `true`) If `true` will display a spinner in the statusbar while flow is type checking.
+* `flow.runOnEdit` (default: `true`) If `true` will run flow on every edit, otherwise will run only when changes are saved.
 
 ## Features
 

--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -15,6 +15,7 @@ import {Status} from './flowStatus'
 import type {DiagnosticCollection, Disposable} from 'vscode';
 
 import {flowFindDiagnostics} from './pkg/flow-base/lib/FlowService';
+import {isRunOnEditEnabled} from './utils/util'
 
 let lastDiagnostics: null | DiagnosticCollection = null;
 const status = new Status()
@@ -37,12 +38,19 @@ export function setupDiagnostics(disposables: Array<Disposable>): void {
 			updateDiagnostics(vscode.window.activeTextEditor.document);
 		}
 	}));
+
+	disposables.push(vscode.workspace.onDidChangeTextDocument(event => {
+		const isDocumentActive = vscode.window.activeTextEditor.document === event.document;
+		if (isDocumentActive && isRunOnEditEnabled()) {
+			updateDiagnostics(event.document, event.document.getText());
+		}
+	}));
 }
 
-async function updateDiagnostics(document) {
+async function updateDiagnostics(document, content:?string) {
 	status.busy()
 	try {
-		let diagnostics = await getDiagnostics(document)
+		let diagnostics = await getDiagnostics(document, content)
 		applyDiagnostics(diagnostics)
 	} catch(error) {
 		console.error(error)
@@ -50,7 +58,7 @@ async function updateDiagnostics(document) {
 	status.idle()
 }
 
-async function getDiagnostics(document) {
+async function getDiagnostics(document, content:?string) {
 	let diags = Object.create(null);
 
 	if (!document) {
@@ -65,7 +73,7 @@ async function getDiagnostics(document) {
 	// flowFindDiagnostics takes the provided filePath and then walks up directories
 	// until a .flowconfig is found. The diagnostics are then valid for the entire
 	// flow workspace.
-	let rawDiag = await flowFindDiagnostics(filePath);
+	let rawDiag = await flowFindDiagnostics(filePath, content);
 	if (rawDiag && rawDiag.messages) {
 		const { flowRoot } = rawDiag;
 

--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -10,12 +10,14 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
+import {Status} from './flowStatus'
 
 import type {DiagnosticCollection, Disposable} from 'vscode';
 
 import {flowFindDiagnostics} from './pkg/flow-base/lib/FlowService';
 
 let lastDiagnostics: null | DiagnosticCollection = null;
+const status = new Status()
 
 export function setupDiagnostics(disposables: Array<Disposable>): void {
 
@@ -37,8 +39,15 @@ export function setupDiagnostics(disposables: Array<Disposable>): void {
 	}));
 }
 
-function updateDiagnostics(document): void {
-	getDiagnostics(document).then((diag) => applyDiagnostics(diag)).catch((error) => console.error(error.toString()));
+async function updateDiagnostics(document) {
+	status.busy()
+	try {
+		let diagnostics = await getDiagnostics(document)
+		applyDiagnostics(diagnostics)
+	} catch(error) {
+		console.error(error)
+	}
+	status.idle()
 }
 
 async function getDiagnostics(document) {

--- a/lib/flowStatus.js
+++ b/lib/flowStatus.js
@@ -1,0 +1,67 @@
+/* @flow */
+
+/*
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ the root directory of this source tree.
+ */
+
+import { window, StatusBarAlignment } from 'vscode';
+import { isFlowStatusEnabled } from './utils/util'
+import type { StatusBarItem } from 'vscode';
+import Spinner from 'elegant-spinner';
+
+export class Status {
+  statusBarItem:StatusBarItem;
+  state:?{id:number}
+
+  static spin:() => string = Spinner()
+  static createStatusBarItem() {
+    const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
+    statusBarItem.tooltip = 'Flow is type checking';
+    return statusBarItem;
+  }
+  static render(status:Status):void {
+    return status.render();
+  }
+  constructor() {
+    this.statusBarItem = Status.createStatusBarItem();
+  }
+  isBusy() {
+    return this.state != null
+  }
+  idle() {
+    this.update(false);
+  }
+  busy() {
+    this.update(isFlowStatusEnabled());
+  }
+  update(busy:boolean) {
+    const {state} = this
+    if (state && !busy) {
+      clearInterval(state.id)
+      this.state = null
+    }
+
+    if (!state && busy) {
+      this.state = {id: setInterval(Status.render, 100, this)}
+    }
+    
+    if (state != this.state) {
+      this.render()
+    }
+  }
+  render() {
+    if (this.isBusy()) {
+      this.statusBarItem.show();
+      this.statusBarItem.text = Status.spin()
+    } else {
+      this.statusBarItem.hide();
+      this.statusBarItem.text = ``
+    }
+  }
+}
+
+export default Status;

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -14,6 +14,10 @@ export function isFlowEnabled() {
 	return workspace.getConfiguration('flow').get('enabled')
 }
 
+export function isFlowStatusEnabled():boolean {
+	return workspace.getConfiguration('flow').get('showStatus')
+}
+
 export function checkNode() {
 	try {
 		const check = spawn(process.platform === 'win32' ? 'where' : 'which', ['node'])

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -18,6 +18,10 @@ export function isFlowStatusEnabled():boolean {
 	return workspace.getConfiguration('flow').get('showStatus')
 }
 
+export function isRunOnEditEnabled():boolean {
+	return workspace.getConfiguration('flow').get('runOnEdit')
+}
+
 export function checkNode() {
 	try {
 		const check = spawn(process.platform === 'win32' ? 'where' : 'which', ['node'])

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
                     "default": true,
                     "description": "If true will display flow status is the statusbar"
                 },
+                "flow.runOnEdit": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "If true will run flow on every edit, otherwise will run only when changes are saved"
+                },
                 "flow.stopFlowOnExit": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
                     "default": "flow",
                     "description": "Path to flow binary. On Windows use '\\\\' as directory separator"
                 },
+                "flow.showStatus": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "If true will display flow status is the statusbar"
+                },
                 "flow.stopFlowOnExit": {
                     "type": "boolean",
                     "default": true,
@@ -72,7 +77,8 @@
         "rxjs": "^5.0.0-beta.8",
         "semver": "^5.3.0",
         "shell-quote": "^1.6.0",
-        "temp": "^0.8.3"
+        "temp": "^0.8.3",
+        "elegant-spinner": "^1.0.1"
     },
     "devDependencies": {
         "babel-cli": "^6.1.4",


### PR DESCRIPTION
Please note that this pull unfortunately includes changes from #85, I'll rebase this once hopefully #85 lands. This change implements short term solution described in #26. To be clear if you have edits in multiple files that aren't saved, it will report errors for the active document as if it was saved but will ignore all other unsaved changes because:

1. Trying to type check as if all unsaved changes were saved isn't necessarily a desired or expected behavior. I personally like to make edits to files until it type checks and only then move on to other file. When I get blocked, I tend to move on to other file, with a plan to return to the blocker. With such work flow type checking all unsaved changes isn't a desired option.
2. From what I understand currently it's not possible to do that anyway.
