### PR TITLE
Do not report obsolete diagnostics.

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -29,7 +29,9 @@ export function setupDiagnostics(context:ExtensionContext): void {
 
 	// Update diagnostics: when active text editor changes
 	subscriptions.push(vscode.window.onDidChangeActiveTextEditor(editor => {
-		updateDiagnostics(context, editor && editor.document);
+		if (editor) {
+			updateDiagnostics(context, editor.document);
+		}
 	}));
 
 	// Update diagnostics when document is edited
@@ -42,33 +44,73 @@ export function setupDiagnostics(context:ExtensionContext): void {
 	subscriptions.push(vscode.workspace.onDidChangeTextDocument(event => {
 		const isDocumentActive = vscode.window.activeTextEditor.document === event.document;
 		if (isDocumentActive && isRunOnEditEnabled()) {
-			updateDiagnostics(context, event.document, event.document.getText());
+			updateDiagnostics(context, event.document);
 		}
 	}));
 }
 
-async function updateDiagnostics(context:ExtensionContext, document:TextDocument, content:?string) {
-	status.busy()
+const pendingDiagnostics:Map<string, number> = new Map()
+
+function updateDiagnostics(context:ExtensionContext, document:TextDocument) {
+	const {uri, version} = document
+	const id = uri.toString()
+	const pendingVersion = pendingDiagnostics.get(id)
+	if (pendingVersion == null) {
+		requestDiagnostics(context, document)
+	} else if (pendingVersion !== version) {
+		abortDiagnostics(id)
+		requestDiagnostics(context, document)
+	}
+}
+
+function abortDiagnostics(id) {
+	if (pendingDiagnostics.has(id)) {
+		pendingDiagnostics.delete(id)
+	}
+
+	if (pendingDiagnostics.size === 0) {
+		status.idle()
+	}
+}
+
+
+async function requestDiagnostics(context:ExtensionContext, document:TextDocument) {
+	const {uri, version} = document
+	const id = uri.toString()
+	pendingDiagnostics.set(id, version)
+	if (pendingDiagnostics.size > 0) {
+		status.busy()
+	}
 	try {
-		let diagnostics = await getDiagnostics(context, document, content)
-		applyDiagnostics(diagnostics)
-	} catch(error) {
+		let diagnostics = await getDocumentDiagnostics(context, document)
+		if (pendingDiagnostics.get(id) === version) {
+			applyDiagnostics(diagnostics)
+		}
+	} catch (error) {
 		console.error(error)
 	}
-	status.idle()
-}
 
-const noDiagnostics = Object.create(null);
+	if (pendingDiagnostics.get(id) === version) {
+		pendingDiagnostics.delete(id)
+	}
 
-async function getDiagnostics(context:ExtensionContext, document:TextDocument, content:?string) {
-	if (!document) {
-		return noDiagnostics;
-	} else if (document.isUntitled) {
-		return getBufferDiagnostics(context, document, content);
-	} else {
-		return getFileDiagnostics(document.uri.fsPath, content);
+	if (pendingDiagnostics.size === 0) {
+		status.idle()
 	}
 }
+
+async function getDocumentDiagnostics(context:ExtensionContext, document:TextDocument) {
+	if (document.isUntitled) {
+		return getDraftDocumentDiagnostics(context, document)
+	} else if (document.isDirty) {
+		return getDirtyDocumentDiagnostics(context, document)
+	} else {
+		return getSavedDocumentDiagnostics(context, document)
+	}
+}
+
+
+const noDiagnostics = Object.create(null);
 
 
 async function getFileDiagnostics(filePath:string, content:?string, pathToURI=toURI) {
@@ -135,25 +177,31 @@ async function getFileDiagnostics(filePath:string, content:?string, pathToURI=to
 
 const supportedLanguages = new Set(["javascript", "javascriptreact"]);
 
-async function getBufferDiagnostics(context:ExtensionContext, document:TextDocument, content:?string) {
+async function getDraftDocumentDiagnostics(context:ExtensionContext, document:TextDocument) {
 	if (supportedLanguages.has(document.languageId)) {
-		const code = content
-			? content
-			: document.getText();
-		if (hasFlowPragma(code)) {
+		const content = document.getText();
+		if (hasFlowPragma(content)) {
 			const tryPath = getTryPath(context)
 			const uri = document.uri
 			const pathToURI = path =>
 				( path == tryPath
 				? uri
-				: toURI(path)
+				: uri
 				)
 
-			return getFileDiagnostics(tryPath, code, pathToURI);
+			return getFileDiagnostics(tryPath, content, pathToURI);
 		}
 	}
 
 	return noDiagnostics;
+}
+
+async function getDirtyDocumentDiagnostics(context:ExtensionContext, document:TextDocument) {
+	return getFileDiagnostics(document.uri.fsPath, document.getText());
+}
+
+async function getSavedDocumentDiagnostics(context:ExtensionContext, document:TextDocument) {
+	return getFileDiagnostics(document.uri.fsPath, null);
 }
 
 function mapSeverity(sev: string) {


### PR DESCRIPTION
With this change extension tracks requested diagnostics, so that obsolete reports can be ignored. I don't know yet to what degree this fixes issues reported in https://github.com/flowtype/flow-for-vscode/pull/91#issuecomment-287220095 but I thought I'd send the pull to give an idea where I'm heading with this.