### PR TITLE
use js-beautify for Flow Type hovers

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 <PROJECT_ROOT>/node_modules/.*/spec/.*
+.*/node_modules/config-chain/test/broken.json
 
 [include]
 

--- a/lib/flowHover.js
+++ b/lib/flowHover.js
@@ -9,6 +9,7 @@
  */
 
 import * as vscode from 'vscode'
+import { js_beautify } from 'js-beautify'
 
 import {flowGetType} from './pkg/flow-base/lib/FlowService'
 
@@ -34,9 +35,10 @@ export class HoverSupport {
 		)
 
 		if (completions) {
+			const beautifiedData = js_beautify(completions.type, { indent_size: 4 });
 			return new vscode.Hover([
 				'[Flow]',
-				{language: 'javascript', value: `${word}: ${completions.type}`}
+				{language: 'javascript', value: `${word}: ${beautifiedData}`}
 			])
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "event-kit": "^2.0.0",
         "fs-plus": "^2.8.2",
         "fuzzaldrin": "^2.1.0",
+        "js-beautify": "^1.6.12",
         "log4js": "^0.6.37",
         "lru-cache": "^4.0.1",
         "mkdirp": "^0.5.1",


### PR DESCRIPTION
Huge fan of this library! Been using it a lot when working with Flow at my current job.

When working with complex types that are deeply nested, it's hard to read through the whole type tooltip because there is no indentation.

This PR is based off the Flow type tooltips from this other plugin: https://github.com/gcazaciuc/vscode-flow-ide. This seems to be no longer actively worked on, with functionality being ported over to this library.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0k2D0G012f202b3S3T3f/Screen%20Recording%202017-03-29%20at%2005.25%20PM.gif?v=004d1a3d)