### PR TITLE
Remove redundant [flow] annotation

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -119,7 +119,7 @@ async function getFileDiagnostics(filePath:string, content:?string, pathToURI=to
 				msg = `${msg} (${details.join(' ')})`;
 			}
 
-			diag.msg = `[flow] ${msg}`;
+			diag.msg = msg;
 
 			if (!diags[file]) {
 				diags[file] = {uri, reports:[]}


### PR DESCRIPTION
**Summary**

There's some redundancy in messages displayed by flow extension. This PR attempts to remove extra `[flow]` annotation which is unnecessary, as it's already present in message.

Before:

<img width="537" alt="screen shot 2017-04-08 at 23 38 43" src="https://cloud.githubusercontent.com/assets/5106466/24832659/98808f20-1cb4-11e7-9478-74a9b3fe120d.png">

<img width="515" alt="screen shot 2017-04-08 at 23 40 13" src="https://cloud.githubusercontent.com/assets/5106466/24832667/c404650e-1cb4-11e7-96b8-b7b3007850b1.png">


After:

<img width="498" alt="screen shot 2017-04-08 at 23 38 51" src="https://cloud.githubusercontent.com/assets/5106466/24832660/9880cd6e-1cb4-11e7-801f-9ae1d1a8029f.png">

<img width="523" alt="screen shot 2017-04-08 at 23 39 50" src="https://cloud.githubusercontent.com/assets/5106466/24832666/c4039570-1cb4-11e7-8b74-94282b66af3c.png">