### PR TITLE
Add flow coverage support

### DIFF
--- a/lib/flowCoverage.js
+++ b/lib/flowCoverage.js
@@ -1,0 +1,105 @@
+/* @flow */
+
+/*
+ Copyright (c) 2015-present, Facebook, Inc.
+ All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ the root directory of this source tree.
+ */
+
+import * as vscode from 'vscode';
+import type { StatusBarItem } from 'vscode';
+import { flowGetCoverage } from './pkg/flow-base/lib/FlowService';
+import type {FlowCoverageResult} from './pkg/flow-base/lib/FlowService';
+import type {DiagnosticCollection, ExtensionContext, TextDocument, Uri} from 'vscode';
+
+let lastDiagnostics: null | DiagnosticCollection = null;
+
+type State = {
+  showUncovered?: boolean,
+  uri?: ?Uri
+}
+
+export class Coverage {
+  coverageStatus: StatusBarItem;
+  state: State;
+
+  static createStatusBarItem() {
+    const coverageStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    coverageStatus.tooltip = 'Flow type coverage. Click to toggle uncovered code';
+    coverageStatus.command = 'flow.show-coverage';
+    return coverageStatus;
+  }
+
+  constructor() {
+    this.coverageStatus = Coverage.createStatusBarItem();
+    this.state = { showUncovered: false, uri: null };
+
+    vscode.commands.registerCommand('flow.show-coverage', () => {
+      this.setState({ showUncovered: !this.state.showUncovered });
+    });
+  }
+
+  setState(newState: State) {
+    this.state = Object.assign({}, this.state, newState);
+    this.render();
+  }
+
+  update(uri: Uri) {
+    this.setState({ uri });
+  }
+
+  applyDiagnostics(coverageReport: FlowCoverageResult, uri: Uri) {
+    if (lastDiagnostics) {
+      lastDiagnostics.dispose();
+    }
+
+    lastDiagnostics = vscode.languages.createDiagnosticCollection();
+
+    const { uncoveredRanges } = coverageReport;
+
+    const diags = uncoveredRanges.map(item => {
+      const range = new vscode.Range(
+        item.start.line,
+        item.start.column,
+        item.end.line,
+        item.end.column
+      );
+
+      const diag = new vscode.Diagnostic(
+        range,
+        'uncovered code',
+        vscode.DiagnosticSeverity.Information
+      );
+      diag.source = 'flow coverage';
+      return diag;
+    });
+
+    if (this.state.showUncovered) {
+      lastDiagnostics.set(uri, diags);
+    }
+  }
+
+  async render() {
+    const { uri } = this.state;
+    if (!uri) {
+      return null;
+    }
+    this.coverageStatus.show();
+
+    try {
+      const coverageReport = await flowGetCoverage(uri.fsPath);
+      if (coverageReport) {
+        const percentage = typeof coverageReport.percentage === 'number' &&
+          coverageReport.percentage.toFixed(1);
+        this.coverageStatus.text = `Flow: ${percentage.toString()}%`;
+        this.applyDiagnostics(coverageReport, uri);
+      }
+    } catch (e) {
+      this.coverageStatus.text = '';
+    }
+  }
+}
+
+export default Coverage;

--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -11,6 +11,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import {Status} from './flowStatus'
+import {Coverage} from './flowCoverage';
 import {Uri} from 'vscode';
 import type {DiagnosticCollection, ExtensionContext, TextDocument} from 'vscode';
 
@@ -18,7 +19,8 @@ import {flowFindDiagnostics} from './pkg/flow-base/lib/FlowService';
 import {isRunOnEditEnabled, hasFlowPragma, getTryPath, toURI} from './utils/util'
 
 let lastDiagnostics: null | DiagnosticCollection = null;
-const status = new Status()
+const status = new Status();
+const coverage = new Coverage();
 
 export function setupDiagnostics(context:ExtensionContext): void {
 	const {subscriptions} = context
@@ -56,6 +58,7 @@ async function updateDiagnostics(context:ExtensionContext, document:TextDocument
 		console.error(error)
 	}
 	status.idle()
+	coverage.update(document.uri);
 }
 
 const noDiagnostics = Object.create(null);


### PR DESCRIPTION
**Summary**

Flow coverage support. 

StatusBar (clicking toggles uncovered code mode):

<img width="167" alt="screen shot 2017-04-09 at 03 29 35" src="https://cloud.githubusercontent.com/assets/5106466/24833827/e5a73ffe-1cd4-11e7-96cc-066b54bbc5da.png">

Uncovered code mode:

<img width="578" alt="screen shot 2017-04-09 at 03 29 48" src="https://cloud.githubusercontent.com/assets/5106466/24833828/e5a86ce4-1cd4-11e7-81c5-dde0f4abf125.png">

<img width="296" alt="screen shot 2017-04-09 at 03 31 58" src="https://cloud.githubusercontent.com/assets/5106466/24833848/2db6f3d4-1cd5-11e7-8ac4-6fd5683df3d0.png">

