### PR TITLE
Default runOnEdit to be off for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Bundles `flow-bin` with the plugin to use in cases where it has not been
   installed globally or locally. - [@BrainMaestro][] [#118](https://github.com/flowtype/flow-for-vscode/pull/118)
+* Switched `flow.runOnEdit` to default to false for the moment, it's a great idea but we're seeing a lot of hung processes.
+  if you want to help improve this extension, taking a look into this would help us a lot - [@orta][] [#120](https://github.com/flowtype/flow-for-vscode/pull/120)
+
+
 
 ### 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can specify a configuration by amending the VS Code `settings.json` file. Ac
 * `flow.enabled` (default: true) you can disable flow for some Project for example
 * `flow.useNPMPackagedFlow` (default: false) you can also run Flow by defining it in your `package.json`
 * `flow.showStatus` (default: `true`) If `true` will display a spinner in the status-bar while flow is type checking.
-* `flow.runOnEdit` (default: `true`) If `true` will run flow on every edit, otherwise will run only when changes are saved.
+* `flow.runOnEdit` (default: `false`) If `true` will run flow on every edit, otherwise will run only when changes are saved.
 
 ## Features
 
@@ -29,7 +29,7 @@ You can specify a configuration by amending the VS Code `settings.json` file. Ac
 * Go to Definition / Peek Definition
 * Diagnostics (Errors, Warnings)
 * Hover type information
-* Progress indicator
+* Toggle-able Code Coverage reports
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
                 },
                 "flow.runOnEdit": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "If true will run flow on every edit, otherwise will run only when changes are saved"
                 },
                 "flow.stopFlowOnExit": {


### PR DESCRIPTION
Looks like runOnEdit is causing a handful of hung `flow` instances ( after ~15m I ended up with 6-7 flow instances.

![screen shot 2017-04-25 at 09 23 21](https://cloud.githubusercontent.com/assets/49038/25375521/db14e23c-2998-11e7-8ce2-f41c2836a354.png)

So I've defaulted this to off , and updated the README - and also included a fix for #119 