### PR TITLE
Add support for the .js.flow file extension

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -131,7 +131,7 @@ async function getDocumentDiagnostics(context: ExtensionContext, document: TextD
 const noDiagnostics = Object.create(null);
 
 async function getFileDiagnostics(filePath: string, content: ?string, pathToURI = toURI) {
-  if (path.extname(filePath) !== '.js' && path.extname(filePath) !== '.jsx') {
+  if (path.extname(filePath) !== '.js' && path.extname(filePath) !== '.jsx' && path.extname(filePath) !== '.flow') {
     return noDiagnostics; // we only check on JS files
   }
 


### PR DESCRIPTION
The `flow` command will search for files with this extension, and report errors in them, and it seems to cause strange bugs when they are ignored by the extension.

The better solution would be to use `document.languageId` and let vscode handle the extension mapping, but this is the simplest change that fixes my issue.

This fixes #139 for me.