### PR TITLE
Add flow.fileExtensions configuration setting for file extensions

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -15,7 +15,7 @@ import {Uri} from 'vscode';
 import {flowFindDiagnostics} from './pkg/flow-base/lib/FlowService';
 import {Status} from './flowStatus';
 import {Coverage} from './flowCoverage';
-import {isRunOnEditEnabled, hasFlowPragma, getTryPath, toURI} from './utils/util';
+import {isRunOnEditEnabled, hasFlowPragma, getFileExtensions, getTryPath, toURI} from './utils/util';
 import debounce from 'lodash.debounce';
 
 const ON_CHANGE_TEXT_TIMEOUT = 500;
@@ -110,7 +110,7 @@ async function requestDiagnostics(context: ExtensionContext, document: TextDocum
   coverage.update(document.uri);
 
   if (pendingDiagnostics.get(id) === version) {
-    pendingDiagnostics.delete(id);
+    pendingDiagnostics.delete(id); getFileExtensions
   }
 
   if (pendingDiagnostics.size === 0) {
@@ -131,8 +131,9 @@ async function getDocumentDiagnostics(context: ExtensionContext, document: TextD
 const noDiagnostics = Object.create(null);
 
 async function getFileDiagnostics(filePath: string, content: ?string, pathToURI = toURI) {
-  if (path.extname(filePath) !== '.js' && path.extname(filePath) !== '.jsx') {
-    return noDiagnostics; // we only check on JS files
+  const extensions = getFileExtensions();
+  if (extensions.indexOf(path.extname(filePath)) === -1) {
+    return noDiagnostics;
   }
 
   // flowFindDiagnostics takes the provided filePath and then walks up directories

--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -110,7 +110,7 @@ async function requestDiagnostics(context: ExtensionContext, document: TextDocum
   coverage.update(document.uri);
 
   if (pendingDiagnostics.get(id) === version) {
-    pendingDiagnostics.delete(id); getFileExtensions
+    pendingDiagnostics.delete(id);
   }
 
   if (pendingDiagnostics.size === 0) {

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -28,7 +28,7 @@ export function shouldRunOnAllFiles():boolean {
 	return workspace.getConfiguration('flow').get('runOnAllFiles')
 }
 
-export function getFileExtensions():boolean {
+export function getFileExtensions():Array<string> {
 	return workspace.getConfiguration('flow').get('fileExtensions')
 }
 

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -25,7 +25,11 @@ export function isRunOnEditEnabled():boolean {
 }
 
 export function shouldRunOnAllFiles():boolean {
-    return workspace.getConfiguration('flow').get('runOnAllFiles')
+	return workspace.getConfiguration('flow').get('runOnAllFiles')
+}
+
+export function getFileExtensions():boolean {
+	return workspace.getConfiguration('flow').get('fileExtensions')
 }
 
 export function getTryPath(context:ExtensionContext):string {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,14 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Run Flow on all files, No need to put //@flow comment on top of files."
+                },
+                "flow.fileExtensions": {
+                    "type": "array",
+                    "default": [".js", ".mjs", ".jsx", ".flow", ".json"],
+                    "description": "File extensions to consider for flow processing.",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },


### PR DESCRIPTION
This PR allows the user to set the file extensions to consider for flow processing.  This resolves PR #145.

Currently `flow-for-vscode` is [hardcoded](https://github.com/flowtype/flow-for-vscode/blob/master/lib/flowDiagnostics.js#L134-L136) to only consider `.js, .jsx` file extensions.

NOTE: The solution in this PR is not ideal and should reach into the `.flowconfig` relevant for the file being considered for checking - but it looked like that would take a reasonable amount of refactoring of the code flow.