### PR TITLE
bugfix: don't cache activeTextEditor used in workspace event handlers

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -25,12 +25,11 @@ let lastDiagnostics: null | DiagnosticCollection = null;
 
 export function setupDiagnostics(context: ExtensionContext): void {
   const {subscriptions} = context;
-  const {activeTextEditor} = vscode.window;
   const debouncedUpdateDiagnostics = debounce(updateDiagnostics, ON_CHANGE_TEXT_TIMEOUT);
 
   // Do an initial call to get diagnostics from the active editor if any
-  if (activeTextEditor && hasFlowPragma(activeTextEditor.document.getText())) {
-    debouncedUpdateDiagnostics(context, activeTextEditor.document);
+  if (vscode.window.activeTextEditor && hasFlowPragma(vscode.window.activeTextEditor.document.getText())) {
+    debouncedUpdateDiagnostics(context, vscode.window.activeTextEditor.document);
   }
 
   // Update diagnostics when active text editor changes
@@ -45,8 +44,8 @@ export function setupDiagnostics(context: ExtensionContext): void {
   // Update diagnostics when document is saved
   subscriptions.push(
     vscode.workspace.onDidSaveTextDocument(event => {
-      if (activeTextEditor && hasFlowPragma(activeTextEditor.document.getText())) {
-        debouncedUpdateDiagnostics(context, activeTextEditor.document);
+      if (vscode.window.activeTextEditor && hasFlowPragma(vscode.window.activeTextEditor.document.getText())) {
+        debouncedUpdateDiagnostics(context, vscode.window.activeTextEditor.document);
       }
     })
   );
@@ -54,7 +53,7 @@ export function setupDiagnostics(context: ExtensionContext): void {
   // Update diagnostics when document is edited
   subscriptions.push(
     vscode.workspace.onDidChangeTextDocument(event => {
-      const isDocumentActive = activeTextEditor.document === event.document;
+      const isDocumentActive = vscode.window.activeTextEditor.document.fileName === event.document.fileName;
 
       if (isDocumentActive && isRunOnEditEnabled() && hasFlowPragma(event.document.getText())) {
         debouncedUpdateDiagnostics(context, event.document);


### PR DESCRIPTION
This PR fixes #157 (I haven't checked all the issues).

Currently `activeTextEditor` is being [cached](https://github.com/flowtype/flow-for-vscode/blob/master/lib/flowDiagnostics.js#L28) which invalidates checks against `activeTextEditor` within event [handlers](https://github.com/flowtype/flow-for-vscode/blob/master/lib/flowDiagnostics.js#L46-L64).