### PR TITLE
Allow workspaceRoot variable in pathToFlow

### DIFF
--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -164,10 +164,12 @@ async function canFindFlow(flowPath: string): Promise<boolean> {
 
 async function getPathToFlow(): Promise<string> {
   if (!global.cachedPathToFlowBin) {
+    const workspaceRoot = global.vscode.workspace.rootPath;
     const config = global.vscode.workspace.getConfiguration('flow');
     const shouldUseNodeModule = config.get('useNPMPackagedFlow');
-    const userPath = config.get('pathToFlow');
-    const nodeModuleFlowPath = nodeModuleFlowLocation(global.vscode.workspace.rootPath)
+    const userPath = config.get('pathToFlow')
+      .replace('${workspaceRoot}', workspaceRoot);
+    const nodeModuleFlowPath = nodeModuleFlowLocation(workspaceRoot);
 
     if (shouldUseNodeModule && await canFindFlow(nodeModuleFlowPath)){
       global.cachedPathToFlowBin = nodeModuleFlowPath;


### PR DESCRIPTION
`flow.useNPMPackagedFlow` wasn't adequate for my use-cases (node_modules not at root, a copy for flow-bin outside of node-modules, etc). 

I was resorting to this hack: `"postinstall": "cp .vscode/settings.example.json .vscode/settings.json && sed -i '' \"s ROOT_REPLACE_ME $(pwd) \" .vscode/settings.json"`

Ideally this would be solved by vscode; there is an open issue: https://github.com/Microsoft/vscode/issues/2809 however it seems harmless to add this. 

I tested locally with:
- setting defined correctly (`"flow.pathToFlow": "${workspaceRoot}/my-flow"`)
- setting defined incorrectly (`"flow.pathToFlow": "${workspaceRoot}/my-nonexistent-flow"`)
- setting undefined (checking that `.config('pathToFlow').replace` does not throw)