### PR TITLE
Bump Flow to 0.68

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,10 @@
 <PROJECT_ROOT>/node_modules/.*/spec/.*
 .*/node_modules/config-chain/test/broken.json
 
+[untyped]
+<PROJECT_ROOT>/lib/pkg/commons-node
+<PROJECT_ROOT>/lib/pkg/flow-base/lib/FlowHelpers.js
+
 [include]
 
 [libs]
@@ -10,7 +14,5 @@
 suppress_comment=.*\\$FlowFixMe.*
 suppress_comment=.*\\$FlowIssue.*
 
-unsafe.enable_getters_and_setters=true
-
 [version]
-^0.49.0
+^0.68.0

--- a/lib/flowStatus.js
+++ b/lib/flowStatus.js
@@ -15,7 +15,7 @@ import Spinner from 'elegant-spinner';
 
 export class Status {
   statusBarItem:StatusBarItem;
-  state:?{id:number}
+  state:?{id:IntervalID}
 
   static spin:() => string = Spinner()
   static createStatusBarItem() {
@@ -49,7 +49,7 @@ export class Status {
     if (!state && busy) {
       this.state = {id: setInterval(Status.render, 100, this)}
     }
-    
+
     if (state != this.state) {
       this.render()
     }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,13 @@
                 },
                 "flow.fileExtensions": {
                     "type": "array",
-                    "default": [".js", ".mjs", ".jsx", ".flow", ".json"],
+                    "default": [
+                        ".js",
+                        ".mjs",
+                        ".jsx",
+                        ".flow",
+                        ".json"
+                    ],
                     "description": "File extensions to consider for flow processing.",
                     "items": {
                         "type": "string"
@@ -90,7 +96,7 @@
         "dequeue": "^1.0.5",
         "elegant-spinner": "^1.0.1",
         "event-kit": "^2.0.0",
-        "flow-bin": "^0.49.0",
+        "flow-bin": "^0.68.0",
         "fs-plus": "^2.8.2",
         "fuzzaldrin": "^2.1.0",
         "js-beautify": "^1.6.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,9 +1182,9 @@ first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
 
-flow-bin@^0.49.0:
-  version "0.49.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
+flow-bin@^0.68.0:
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Updates Flow to the latest version.

I've added some of `lib/pkg` libs to `[untyped]`, because eventually we're going to remove this dir and delegate defining helpers to `flow-language-server`.