### PR TITLE
[Discussion] [Live Share] Restrict javascriptreact documents to file scheme

### DIFF
--- a/lib/flowLSP.js
+++ b/lib/flowLSP.js
@@ -24,7 +24,10 @@ import { checkNode, checkFlow, isFlowEnabled } from './utils';
 import { setupLogging } from './flowLogging';
 import { clearWorkspaceCaches } from './pkg/flow-base/lib/FlowHelpers';
 
-const languages = [{ language: 'javascript', scheme: 'file' }, 'javascriptreact'];
+const languages = [
+  { language: 'javascript', scheme: 'file' },
+  { language: 'javascriptreact', scheme: 'file' }
+];
 
 export function activate(context: ExtensionContext) {
   if (!isFlowEnabled()) {

--- a/lib/flowMain.js
+++ b/lib/flowMain.js
@@ -23,7 +23,7 @@ import {setupLogging} from "./flowLogging"
 
 const languages = [
 	{ language: 'javascript', scheme: 'file' },
-	'javascriptreact'
+	{ language: 'javascriptreact', scheme: 'file' }
 ]
 
 export function activate(context:ExtensionContext): void {


### PR DESCRIPTION
This PR simply updates the `DocumentSelector` (used for registering language services) to specify a `file` scheme for both the `javascript` and `javascriptreact` languages. 

In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Flow, this PR helps ensure that "guests" within a Live Share session will have their language services be entirely derived from the remote/host side, which provides a more accurate and project-wide experience. "Guests" in Live Share see documents using the `vsls` scheme, and so by limiting to just `file`, this allows the Live Share "proxy language server" to capture language service requests and send them to the local Flow language server on the host's machine (which would see `file` documents).