### PR TITLE
[Live Share] Limit linting to localfiles

### DIFF
--- a/lib/flowDiagnostics.js
+++ b/lib/flowDiagnostics.js
@@ -66,6 +66,10 @@ const pendingDiagnostics: Map<string, number> = new Map();
 
 function updateDiagnostics(context: ExtensionContext, document: TextDocument) {
   const {uri, version} = document;
+  if (uri.scheme !== 'file') {
+    return;
+  }
+
   const id = uri.toString();
   const pendingVersion = pendingDiagnostics.get(id);
 


### PR DESCRIPTION
This is a follow-up to #230, since I forgot to limit diagnostics to local files as well.

// CC @orta 