### PR TITLE
Disable URL-encoding of paths in the language client to make LSP work on Windows

### DIFF
--- a/lib/flowLSP.js
+++ b/lib/flowLSP.js
@@ -63,6 +63,9 @@ export function activate(context: ExtensionContext) {
       // Notify the server about file changes to '.clientrc files contain in the workspace
       fileEvents: workspace.createFileSystemWatcher('**/*.{js,jsx,mjs,js.flow}'),
     },
+    uriConverters: {
+      code2Protocol: uri => uri.toString(true), // this disables URL-encoding for file URLs
+    },
   };
 
   const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 0);


### PR DESCRIPTION
The Flow LS doesn't know how to process url-encoded Windows file paths, making the extension not work on that OS unless it is disabled.

This fixes #238 