### PR TITLE
Document `useLSP` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can specify a configuration by amending the VS Code `settings.json` file. Ac
 * `flow.showStatus` (default: `true`) If `true` will display a spinner in the status-bar while flow is type checking.
 * `flow.runOnEdit` (default: `true`) If `true` will run flow on every edit, otherwise will run only when changes are saved.
 * `flow.runOnAllFiles` (default: `false`) Run Flow on all files, No need to put `//@flow comment` on top of files.
+* `flow.useLSP` (default: `false`) Run Flow through Language Server Protocol [EXPERIMENTAL].
 
 ## Features
 


### PR DESCRIPTION
Looks like I've forgotten to put it in the readme.