### PR TITLE
Add `showUncovered` config option to activate uncovered code report by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can specify a configuration by amending the VS Code `settings.json` file. Ac
 * `flow.enabled` (default: true) you can disable flow for some Project for example.
 * `flow.useNPMPackagedFlow` (default: false) you can also run Flow by defining it in your `package.json`.
 * `flow.showStatus` (default: `true`) If `true` will display a spinner in the status-bar while flow is type checking.
+* `flow.showUncovered` (default: `false`) If `true` will show uncovered code by default.
 * `flow.runOnEdit` (default: `true`) If `true` will run flow on every edit, otherwise will run only when changes are saved.
 * `flow.runOnAllFiles` (default: `false`) Run Flow on all files, No need to put `//@flow comment` on top of files.
 * `flow.useLSP` (default: `false`) Run Flow through Language Server Protocol [EXPERIMENTAL].

--- a/lib/flowCoverage.js
+++ b/lib/flowCoverage.js
@@ -12,6 +12,7 @@ import * as vscode from 'vscode';
 import type { StatusBarItem } from 'vscode';
 import { flowGetCoverage } from './pkg/flow-base/lib/FlowService';
 import type {FlowCoverageResult} from './pkg/flow-base/lib/FlowService';
+import { shouldShowUncoveredCode } from './utils/util'
 import type {DiagnosticCollection, ExtensionContext, TextDocument, Uri} from 'vscode';
 
 let lastDiagnostics: null | DiagnosticCollection = null;
@@ -34,7 +35,7 @@ export class Coverage {
 
   constructor() {
     this.coverageStatus = Coverage.createStatusBarItem();
-    this.state = { showUncovered: false, uri: null };
+    this.state = { showUncovered: shouldShowUncoveredCode(), uri: null };
 
     vscode.commands.registerCommand('flow.show-coverage', () => {
       this.setState({ showUncovered: !this.state.showUncovered });

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -24,6 +24,10 @@ export function isFlowStatusEnabled():boolean {
 	return workspace.getConfiguration('flow').get('showStatus')
 }
 
+export function shouldShowUncoveredCode():boolean {
+	return workspace.getConfiguration('flow').get('showUncovered')
+}
+
 export function isRunOnEditEnabled():boolean {
 	return workspace.getConfiguration('flow').get('runOnEdit')
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
           "default": true,
           "description": "If true will display flow status is the statusbar"
         },
+        "flow.showUncovered": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true will show uncovered code by default"
+        },
         "flow.runOnEdit": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
I find the uncovered code feature to be really helpful. Unfortunately, it is not activated by default and I need to click on the status bar item every time.
I am adding this option to enable it by default while keeping the status bar item toggle working.