### PR TITLE
Use same path to Flow when useLSP is true

### DIFF
--- a/lib/flowLSP.js
+++ b/lib/flowLSP.js
@@ -22,14 +22,14 @@ import {
 } from 'vscode-languageclient';
 import { checkNode, checkFlow, isFlowEnabled } from './utils';
 import { setupLogging } from './flowLogging';
-import { clearWorkspaceCaches } from './pkg/flow-base/lib/FlowHelpers';
+import { clearWorkspaceCaches, getPathToFlow } from './pkg/flow-base/lib/FlowHelpers';
 
 const languages = [
   { language: 'javascript', scheme: 'file' },
   { language: 'javascriptreact', scheme: 'file' }
 ];
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
   if (!isFlowEnabled()) {
     return;
   }
@@ -39,18 +39,27 @@ export function activate(context: ExtensionContext) {
   checkNode();
   checkFlow();
 
+  const pathToFlow = await getPathToFlow();
+
   // The server is implemented in node
   const SERVER_HOME = context.asAbsolutePath(
     path.join('node_modules', 'flow-language-server', 'lib', 'bin', 'cli.js')
   );
 
+  // Use the same path as non-LSP Flow
+  // Disable auto-downloading of Flow binaries
+  const args = ['--flow-path', pathToFlow, '--no-auto-download']
+
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
   const serverOptions: ServerOptions = {
-    run: { module: SERVER_HOME, transport: TransportKind.ipc },
+    run: { module: SERVER_HOME, args, transport: TransportKind.ipc },
     debug: {
       module: SERVER_HOME,
       transport: TransportKind.ipc,
+      args,
+      // If you receive errors when starting the extension in debug mode,
+      // try switching this to --inspect=6009
       options: { execArgv: ['--nolazy', '--debug=6009'] },
     },
   };

--- a/lib/flowLSP.js
+++ b/lib/flowLSP.js
@@ -59,8 +59,8 @@ export async function activate(context: ExtensionContext) {
       transport: TransportKind.ipc,
       args,
       // If you receive errors when starting the extension in debug mode,
-      // try switching this to --inspect=6009
-      options: { execArgv: ['--nolazy', '--debug=6009'] },
+      // try switching this to the deprecated command, --debug=6009
+      options: { execArgv: ['--nolazy', '--inspect=6009'] },
     },
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ import { useLSP } from './utils';
 
 export function activate(context: ExtensionContext) {
   if (useLSP()) {
-    require('./flowLSP').activate(context);
+    return require('./flowLSP').activate(context);
   } else {
     require('./flowMain').activate(context);
   }

--- a/lib/pkg/flow-base/lib/FlowHelpers.js
+++ b/lib/pkg/flow-base/lib/FlowHelpers.js
@@ -14,11 +14,12 @@ import type {LRUCache} from 'lru-cache';
 import type {FlowLocNoSource} from './flowOutputTypes';
 
 import nuclideUri from '../../nuclide-remote-uri/lib/main';
-import {checkOutput} from '../../commons-node/process';
+import {checkOutput, asyncExecute} from '../../commons-node/process';
 import fsPromise from '../../commons-node/fsPromise';
 import LRU from 'lru-cache';
 import invariant from 'assert';
 import path from 'path';
+import os from 'os';
 
 import {getLogger} from '../../nuclide-logging/lib/main';
 const logger = getLogger();
@@ -154,6 +155,20 @@ async function canFindFlow(flowPath: string): Promise<boolean> {
   }
 }
 
+async function getFlowAbsolutePath(flowPath: string): Promise<?string> {
+  const {command, args} = buildSearchFlowCommand(flowPath)
+  const result = await asyncExecute(command, args, {});
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  const flowExecutable = process.platform === 'win32' ? 'flow.cmd' : 'flow';
+  const files = result.stdout.split(os.EOL).filter(f => f.endsWith(flowExecutable));
+  if (files.length === 0) {
+    return null;
+  }
+  return files[0];
+}
+
 /**
  * @return The path to Flow on the user's machine. First using the the user's 
  *   config, then looking into the node_modules for the project.
@@ -174,9 +189,9 @@ async function getPathToFlow(): Promise<string> {
     if (shouldUseNodeModule && await canFindFlow(nodeModuleFlowPath)){
       global.cachedPathToFlowBin = nodeModuleFlowPath;
     } else if (await canFindFlow(userPath)) {
-      global.cachedPathToFlowBin = userPath;
+      global.cachedPathToFlowBin = await getFlowAbsolutePath(userPath);
     } else if (await canFindFlow('flow')) {
-      global.cachedPathToFlowBin = 'flow';
+      global.cachedPathToFlowBin = await getFlowAbsolutePath('flow');
     } else {
       const extensionRoot = path.resolve(__dirname, '../../../../');
       global.cachedPathToFlowBin = nodeModuleFlowLocation(extensionRoot)


### PR DESCRIPTION
Currently, when `useLSP` is true, the extension ignores the `Path To Flow` and `Use NPMPackaged Flow` settings and attempts to download the appropriate flow binary for the project. This PR switches flow-language-server to always take a path to the flow binary, using the same resolution process as when `useLSP` is false. 

Tested on Mac and Windows with global Flow, npm-packaged flow, and extension-bundled Flow.

### Other changes

* Disabled the auto-downloading function of flow-language-server. Since it's not exposed to the extension users, it feels hard to reason about. See #273, https://github.com/flowtype/flow-language-server/issues/79
* Switched `--debug` to `--inspect` when debugging the extension in LSP mode -- this was causing a crash when using the current LTS version of node.

### Caveats

* flow-language-server requires an absolute path. This isn't too much of a burden as we already have some code in place for fetching the path to flow.
* There's a notification that displays the path to flow when the extension starts up in LSP mode:

![screen shot 2018-10-14 at 7 06 06 pm](https://user-images.githubusercontent.com/767083/46923912-3d230b00-cfe4-11e8-9a0e-1801146db842.png)

This originates [from flow-language-server](https://github.com/flowtype/flow-language-server/blob/e4285d843ebe38afcf36f894446081df2433580b/packages/flow-language-server/src/index.js#L189), and I'm not sure if there's a way to disable it from outside the package.

Fixes #273