### PR TITLE
[WIP][RFC]  Move to native flow LSP

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,4 +15,4 @@ suppress_comment=.*\\$FlowFixMe.*
 suppress_comment=.*\\$FlowIssue.*
 
 [version]
-^0.68.0
+^0.88.0

--- a/lib/flowLSP.js
+++ b/lib/flowLSP.js
@@ -29,6 +29,8 @@ const languages = [
   { language: 'javascriptreact', scheme: 'file' }
 ];
 
+console.log(workspace);
+
 export async function activate(context: ExtensionContext) {
   if (!isFlowEnabled()) {
     return;
@@ -40,33 +42,20 @@ export async function activate(context: ExtensionContext) {
   checkFlow();
 
   const pathToFlow = await getPathToFlow();
-
-  // The server is implemented in node
-  const SERVER_HOME = context.asAbsolutePath(
-    path.join('node_modules', 'flow-language-server', 'lib', 'bin', 'cli.js')
-  );
-
-  // Use the same path as non-LSP Flow
-  // Disable auto-downloading of Flow binaries
-  const args = ['--flow-path', pathToFlow, '--no-auto-download']
-
-  // If the extension is launched in debug mode then the debug server options are used
-  // Otherwise the run options are used
+  
   const serverOptions: ServerOptions = {
-    run: { module: SERVER_HOME, args, transport: TransportKind.ipc },
-    debug: {
-      module: SERVER_HOME,
-      transport: TransportKind.ipc,
-      args,
-      // If you receive errors when starting the extension in debug mode,
-      // try switching this to the deprecated command, --debug=6009
-      options: { execArgv: ['--nolazy', '--inspect=6009'] },
-    },
+    command: pathToFlow,
+    args: ['lsp'],
   };
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     documentSelector: languages,
+    // $FlowFixMe: https://code.visualstudio.com/docs/extensionAPI/vscode-api#_workspace
+    rootPath: workspace.workspaceFolders[0],
+    initializationOptions:{
+      
+    },
     synchronize: {
       configurationSection: 'flow',
       // Notify the server about file changes to '.clientrc files contain in the workspace
@@ -81,7 +70,13 @@ export async function activate(context: ExtensionContext) {
   let serverRunning: boolean = false;
 
   // Create the language client and start the client.
-  const client = new LanguageClient('flow', 'Flow', serverOptions, clientOptions);
+  const client = new LanguageClient(
+    'flow',
+    'Flow', 
+    serverOptions,
+    clientOptions,
+  );
+
   const defaultErrorHandler: ErrorHandler = client.createDefaultErrorHandler();
   const running = 'Flow server is running.';
   const stopped = 'Flow server stopped.';

--- a/lib/flowLSP.js
+++ b/lib/flowLSP.js
@@ -29,8 +29,6 @@ const languages = [
   { language: 'javascriptreact', scheme: 'file' }
 ];
 
-console.log(workspace);
-
 export async function activate(context: ExtensionContext) {
   if (!isFlowEnabled()) {
     return;

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "dequeue": "^1.0.5",
     "elegant-spinner": "^1.0.1",
     "event-kit": "^2.0.0",
-    "flow-bin": "^0.68.0",
+    "flow-bin": "^0.88.0",
     "flow-language-server": "^0.6.0",
     "fs-plus": "^2.8.2",
     "fuzzaldrin": "^2.1.0",


### PR DESCRIPTION
Flow natively supports the LSP now, so we can start to move this plugin over to the native Flow LSP.

I have 0 experience with LSP or VSCode extensions, so I'm looking for a lot of feedback here from people who know this technology better than I do.

I wanted to get the ball rolling on this quickly, since nuclide recently announced that it is retiring. If you feel like you can get this done quicker than I can, feel free to take over this PR.

Relevant configuration parsing in flow is here: https://github.com/facebook/flow/blob/master/hack/utils/lsp_fmt.ml#L799

I've tested by running the plugin via the instructions in CONTRIBUTING.md and writing flow with errors to see if the LSP catches them. It does. Here is my flow server log, which you can see is using the LSP:
[log.txt](https://github.com/flowtype/flow-for-vscode/files/2677579/log.txt)

