### PR TITLE
fix: activate plugin only for js projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   ],
   "private": true,
   "activationEvents": [
-    "*"
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "workspaceContains:**/.flowconfig"
   ],
   "main": "./build/index.js",
   "contributes": {


### PR DESCRIPTION
fixes #321