### PR TITLE
feat(vscode): allow clickable links on hover for type descriptions

### DIFF
--- a/lib/flowLSP/FlowLanguageClient/createMiddleware.js
+++ b/lib/flowLSP/FlowLanguageClient/createMiddleware.js
@@ -12,7 +12,7 @@
 import * as vscode from 'vscode';
 import * as lsp from '../utils/LanguageClient';
 import FlowconfigCache from '../utils/FlowconfigCache';
-import formatMarkedDownString from '../utils/formatMarkedDownString';
+import formatFlowMarkDownString from '../utils/formatFlowMarkDownString';
 import checkFlowVersionSatisfies from '../utils/checkFlowVersionSatisifies';
 
 export default function createMiddleware(
@@ -208,8 +208,11 @@ function formatHoverContent(value: ?vscode.Hover): ?vscode.Hover {
   // format content
   value.contents = value.contents.map((content) => {
     // NOTE: in our case, content is always MarkdownString
-    if (content instanceof vscode.MarkdownString) {
-      return formatMarkedDownString(content);
+    if (
+      content instanceof vscode.MarkdownString &&
+      content.value.includes('```flow')
+    ) {
+      return formatFlowMarkDownString(content);
     }
     return content;
   });

--- a/lib/flowLSP/FlowLanguageClient/createMiddleware.js
+++ b/lib/flowLSP/FlowLanguageClient/createMiddleware.js
@@ -207,7 +207,7 @@ function formatHoverContent(value: ?vscode.Hover): ?vscode.Hover {
 
   // format content
   value.contents = value.contents.map((content) => {
-    // NOTE: in our case, content is always MarkdownString
+    // NOTE: only re-format a flow specific MarkdownString so we preserve markdown in type comments
     if (
       content instanceof vscode.MarkdownString &&
       content.value.includes('```flow')

--- a/lib/flowLSP/utils/formatFlowMarkDownString.js
+++ b/lib/flowLSP/utils/formatFlowMarkDownString.js
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 import format from '../../common/format';
 
-export default function formatMarkedDownString(
+export default function formatFlowMarkDownString(
   mdStr: vscode.MarkdownString,
 ): vscode.MarkdownString {
   const code = extractCode(mdStr, 'flow');


### PR DESCRIPTION
`flow-for-vscode` re-formats type descriptions as JavaScript markdown blocks which results in links not being clickable. We should use the default markdown formatter for non-flowtype code blocks.

## Why is this feature important?

Allows package maintainers to provide a better developer experience by adding contextual links.

## Screenshots

### Before
![Screen Shot 2020-11-19 at 4 07 26 PM](https://user-images.githubusercontent.com/127199/99740438-e110f780-2a83-11eb-9a2d-7853ce0c6be9.png)

### After
![Screen Shot 2020-11-19 at 4 25 27 PM](https://user-images.githubusercontent.com/127199/99740444-e53d1500-2a83-11eb-8a89-5456dc528243.png)

## Test case

1. Add a comment to a type:
```js
const DefaultAvatar = ({
  accessibilityLabel,
}: {|
  /** Label for screen readers https://test.com/ */
  accessibilityLabel?: string,
|}) => {
```
2. Hover over the type
3. Ensure the link inside the hover is clickable