### PR TITLE
Add `shell: true` option for modern Node/VSCode

### DIFF
--- a/lib/FlowLanguageClient/FlowLanguageClient.js
+++ b/lib/FlowLanguageClient/FlowLanguageClient.js
@@ -178,6 +178,7 @@ export default class FlowLanguageClient {
         // auto stop flow process
         config.stopFlowOnExit ? '--autostop' : null,
       ].filter(Boolean),
+      options: { shell: true },
 
       // see: clientOptions.workspaceFolder below
       // options: { cwd: flowconfigDir },


### PR DESCRIPTION
Fixes #458 which is necessary for this plugin to work on modern VSCode on Windows.

Personally I still have issues using this plugin in my setup, because of the use of [`bin-version`](https://www.npmjs.com/package/bin-version) which calls [`execa`](https://github.com/sindresorhus/execa) which calls [`cross-spawn`](https://github.com/moxystudio/node-cross-spawn), which doesn't seem to support Flow via `yarn` on Windows (which creates `.js` files but no `.cmd`/.bat` file) — not sure exactly why.